### PR TITLE
Pull pmwiki-tables from Github and fix pkg-resources bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,9 +14,8 @@ MarkdownSubscript==2.1.1
 MarkdownSuperscript==2.1.1
 mdx-bleach==0.1.4
 mdx-linkify==1.2
-mdx-pmwiki-tables==0.1
+-e git+git@github.com:JD-P/mdx_pmwiki_tables.git@master#egg=mdx-pmwiki-tables
 mdx-truly-sane-lists==1.2
-pkg-resources==0.0.0
 promise==2.2.1
 pytz==2018.9
 rcslice==1.1.0


### PR DESCRIPTION
pmwiki-tables isn't a package in PyPI, so I updated the reference to
point to its Github repository. I removed the pkg-resources line,
because that's the result of a bug in Ubuntu [1] [2]

[1]: https://github.com/pypa/pip/issues/4022
[2]: https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1635463